### PR TITLE
Upgrade @jimp/* to v0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@types/lodash": "^4.14.53",
     "@types/node": "^10.11.7",
-    "@jimp/custom": "^0.9.3",
-    "@jimp/types": "^0.9.3",
-    "@jimp/plugin-resize": "^0.9.3",
+    "@jimp/custom": "^0.16.1",
+    "@jimp/types": "^0.16.1",
+    "@jimp/plugin-resize": "^0.16.1",
     "lodash": "^4.17.4",
     "url": "^0.11.0"
   },

--- a/src/image/node.ts
+++ b/src/image/node.ts
@@ -28,7 +28,7 @@ const PROTOCOL_HANDLERS: ProtocalHandlerMap = {
 type NodeImageSource = string | Buffer
 
 export default class NodeImage extends ImageBase {
-  private _image: typeof Jimp
+  private _image: InstanceType<typeof Jimp>
   private _loadByProtocolHandler (handler: ProtocalHandler, src: string): Promise<Buffer> {
     return new Promise<Buffer>((resolve, reject) => {
       handler.get(src, (r: any) => {


### PR DESCRIPTION
This is a security fix for v3.1.x, not v3.2.x. There were no breaking changes between versions of `@jimp/*` other than TypeScript types.

----

Resolve #114