### PR TITLE
Fixes yarn run build:browser

### DIFF
--- a/src/test/common/server.ts
+++ b/src/test/common/server.ts
@@ -6,7 +6,7 @@ import serveStatic = require('serve-static')
 const staticFiles = serveStatic(path.join(__dirname, '../../../fixtures/sample/images/'))
 const serverHandler = (req: http.IncomingMessage, res: http.ServerResponse) => {
   let done = finalhandler(req, res)
-  return staticFiles(<any>req, <any>res, done)
+  return staticFiles(<any>req, <any>res, <any>done)
 }
 
 export const createSampleServer = () => http.createServer(serverHandler)


### PR DESCRIPTION
Before this fix build would fail with this error:

```
ERROR in /Users/joffreyjaffeux/Projects/node-vibrant/src/test/common/server.ts
[tsl] ERROR in /Users/joffreyjaffeux/Projects/node-vibrant/src/test/common/server.ts(9,42)
      TS2345: Argument of type '(err: any) => void' is not assignable to parameter of type '() => void'.
```