### PR TITLE
Upgrade @jimp/* to v0.22.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@types/lodash": "^4.14.53",
     "@types/node": "^10.11.7",
-    "@jimp/custom": "^0.16.1",
-    "@jimp/types": "^0.16.1",
-    "@jimp/plugin-resize": "^0.16.1",
+    "@jimp/custom": "^0.22.12",
+    "@jimp/types": "^0.22.12",
+    "@jimp/plugin-resize": "^0.22.12",
     "lodash": "^4.17.20",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
This change is in order to address security vulnerabilities in phin < v3.7.1 which is used by @jimp/* in v0.16.

https://github.com/advisories/GHSA-x565-32qp-m3vf

There were a few changes marked as `Breaking` inside of @jimp between v0.16 and v0.22.12 but all but 1 were marked that way as they were changing the build tool used by jimp. The one that wasn't is listed below:

- @jimp/core
Switch to fetch for url requests https://github.com/jimp-dev/jimp/pull/1165

They decided to use a polyfill for fetch to support better browser compatibility and I couldn't see any issues this would cause for node-vibrant but am happy to have anyone see if that is an issue.


Addresses: https://github.com/Vibrant-Colors/node-vibrant/issues/146