### PR TITLE
Migrate to named exports for everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Breaking Changes
 
 - You now must import from `node-vibrant/browser`, `node-vibrant/node`, or `node-vibrant/worker` to get the correct environment-specific implementation
-- `Vibrant` class is now a default export
+- `Vibrant` class is now a named export
 - Node 18+ is now required
 - ES5 support is dropped
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ $ npm install node-vibrant
 
 ```typescript
 // Node
-import Vibrant from "node-vibrant/node";
+import { Vibrant } from "node-vibrant/node";
 // Browser
-import Vibrant from "node-vibrant/browser";
+import { Vibrant } from "node-vibrant/browser";
 // Web Worker
-import Vibrant from "node-vibrant/worker";
+import { Vibrant } from "node-vibrant/worker";
 
 // Using builder
 Vibrant.from("path/to/image").getPalette((err, palette) =>

--- a/packages/node-vibrant/__tests__/vibrant.browser.spec.ts
+++ b/packages/node-vibrant/__tests__/vibrant.browser.spec.ts
@@ -1,9 +1,9 @@
 import { commands } from "@vitest/browser/context";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
+import { Vibrant } from "../src/worker";
 import { testVibrant, testVibrantAsPromised } from "./common/helper";
 
-import Vibrant from "../src/worker";
 import type { TestSample } from "../../../fixtures/sample/loader";
 
 beforeAll(async () => {

--- a/packages/node-vibrant/__tests__/vibrant.node.spec.ts
+++ b/packages/node-vibrant/__tests__/vibrant.node.spec.ts
@@ -1,16 +1,14 @@
-import { describe, it, beforeAll, afterAll } from "vitest";
-
-const TEST_PORT = 3444;
+import { afterAll, beforeAll, describe, it } from "vitest";
 
 import { loadTestSamples } from "../../../fixtures/sample/loader";
 
-import { testVibrant, testVibrantAsPromised } from "./common/helper";
-
 import { createSampleServer } from "../../../fixtures/sample/server";
 
-import http from "http";
+import { Vibrant } from "../src/node";
+import { testVibrant, testVibrantAsPromised } from "./common/helper";
+import type http from "node:http";
 
-import Vibrant from "../src/node";
+const TEST_PORT = 3444;
 
 const SAMPLES = loadTestSamples(TEST_PORT);
 

--- a/packages/node-vibrant/src/browser.ts
+++ b/packages/node-vibrant/src/browser.ts
@@ -1,6 +1,6 @@
-import Vibrant from "./configs/browser";
-import pipeline from "./pipeline";
+import { Vibrant } from "./configs/browser";
+import { pipeline } from "./pipeline";
 
 Vibrant.use(pipeline);
 
-export default Vibrant;
+export { Vibrant };

--- a/packages/node-vibrant/src/configs/browser.ts
+++ b/packages/node-vibrant/src/configs/browser.ts
@@ -1,6 +1,6 @@
-import Vibrant from "./config";
-import BrowserImage from "@vibrant/image-browser";
+import { BrowserImage } from "@vibrant/image-browser";
+import { Vibrant } from "./config";
 
 Vibrant.DefaultOpts.ImageClass = BrowserImage;
 
-export default Vibrant;
+export { Vibrant };

--- a/packages/node-vibrant/src/configs/config.ts
+++ b/packages/node-vibrant/src/configs/config.ts
@@ -1,7 +1,7 @@
-import Vibrant from "@vibrant/core";
+import { Vibrant } from "@vibrant/core";
 
 Vibrant.DefaultOpts.quantizer = "mmcq";
 Vibrant.DefaultOpts.generators = ["default"];
 Vibrant.DefaultOpts.filters = ["default"];
 
-export default Vibrant;
+export { Vibrant };

--- a/packages/node-vibrant/src/node.ts
+++ b/packages/node-vibrant/src/node.ts
@@ -1,8 +1,8 @@
-import Vibrant from "./configs/config";
-import NodeImage from "@vibrant/image-node";
-import pipeline from "./pipeline";
+import { NodeImage } from "@vibrant/image-node";
+import { Vibrant } from "./configs/config";
+import { pipeline } from "./pipeline";
 
 Vibrant.DefaultOpts.ImageClass = NodeImage;
 Vibrant.use(pipeline);
 
-export default Vibrant;
+export { Vibrant };

--- a/packages/node-vibrant/src/pipeline/index.ts
+++ b/packages/node-vibrant/src/pipeline/index.ts
@@ -1,9 +1,9 @@
-import MMCQ from "@vibrant/quantizer-mmcq";
-import DefaultGenerator from "@vibrant/generator-default";
+import { MMCQ } from "@vibrant/quantizer-mmcq";
+import { DefaultGenerator } from "@vibrant/generator-default";
 
 import { BasicPipeline } from "@vibrant/core";
 
-const pipeline = new BasicPipeline().filter
+export const pipeline = new BasicPipeline().filter
 	.register(
 		"default",
 		(r: number, g: number, b: number, a: number) =>
@@ -11,5 +11,3 @@ const pipeline = new BasicPipeline().filter
 	)
 	.quantizer.register("mmcq", MMCQ)
 	.generator.register("default", DefaultGenerator);
-
-export default pipeline;

--- a/packages/node-vibrant/src/pipeline/index.worker.ts
+++ b/packages/node-vibrant/src/pipeline/index.worker.ts
@@ -1,4 +1,4 @@
 import { runPipelineInWorker } from "@vibrant/core";
-import pipeline from "./";
+import { pipeline } from "./";
 
 runPipelineInWorker(self, pipeline);

--- a/packages/node-vibrant/src/worker.ts
+++ b/packages/node-vibrant/src/worker.ts
@@ -1,8 +1,8 @@
-import Vibrant from "./configs/browser";
 import { WorkerPipeline } from "@vibrant/core";
+import { Vibrant } from "./configs/browser";
 
 import PipelineWorker from "./pipeline/index.worker?worker";
 
 Vibrant.use(new WorkerPipeline(PipelineWorker as never));
 
-export default Vibrant;
+export { Vibrant };

--- a/packages/vibrant-core/__tests__/builder.spec.ts
+++ b/packages/vibrant-core/__tests__/builder.spec.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest";
 
-import Builder from "../src/builder";
+import { Builder } from "../src/builder";
 
 describe("builder", () => {
 	it("modifies Vibrant options", () => {

--- a/packages/vibrant-core/src/builder.ts
+++ b/packages/vibrant-core/src/builder.ts
@@ -1,12 +1,13 @@
-import { Options } from "./options";
-import { Callback } from "@vibrant/types";
-import { ImageClass, ImageSource } from "@vibrant/image";
-
-import { Filter, Palette } from "@vibrant/color";
-import Vibrant from "./";
+import { Filter } from "@vibrant/color";
 import { assignDeep } from "./utils";
+import { Vibrant } from "./";
+import type { Callback } from "@vibrant/types";
+import type { ImageClass, ImageSource } from "@vibrant/image";
 
-export default class Builder {
+import type { Palette } from "@vibrant/color";
+import type { Options } from "./options";
+
+export class Builder {
 	private _src: ImageSource;
 	private _opts: Partial<Options>;
 	constructor(src: ImageSource, opts: Partial<Options> = {}) {

--- a/packages/vibrant-core/src/index.ts
+++ b/packages/vibrant-core/src/index.ts
@@ -1,18 +1,19 @@
-import { buildProcessOptions, Options } from "./options";
-import { Callback } from "@vibrant/types";
-import { Image, ImageSource } from "@vibrant/image";
-
-import { Palette } from "@vibrant/color";
-
-import Builder from "./builder";
-import { Pipeline, ProcessOptions, ProcessResult } from "./pipeline";
+import { buildProcessOptions } from "./options";
+import { Builder } from "./builder";
 import { assignDeep } from "./utils";
+import type { Options } from "./options";
+import type { Callback } from "@vibrant/types";
+import type { Image, ImageSource } from "@vibrant/image";
+
+import type { Palette } from "@vibrant/color";
+
+import type { Pipeline, ProcessOptions, ProcessResult } from "./pipeline";
 
 export interface VibrantStatic {
 	from(src: ImageSource): Builder;
 }
 
-export default class Vibrant {
+export class Vibrant {
 	private _result: ProcessResult | undefined;
 	private static _pipeline: Pipeline;
 
@@ -73,12 +74,12 @@ export default class Vibrant {
 		const cb = typeof arg0 === "string" ? arg1 : arg0;
 		const image = new this.opts.ImageClass();
 		try {
-			let image1 = await image.load(this._src);
-			let result1: ProcessResult = await this._process(image1, {
+			const image1 = await image.load(this._src);
+			const result1: ProcessResult = await this._process(image1, {
 				generators: [name],
 			});
 			this._result = result1;
-			let res = result1.palettes[name];
+			const res = result1.palettes[name];
 			if (!res) {
 				throw new Error(`Palette with name ${name} not found`);
 			}
@@ -110,12 +111,12 @@ export default class Vibrant {
 		const cb = Array.isArray(arg0) ? arg1 : arg0;
 		const image = new this.opts.ImageClass();
 		try {
-			let image1 = await image.load(this._src);
-			let result1: ProcessResult = await this._process(image1, {
+			const image1 = await image.load(this._src);
+			const result1: ProcessResult = await this._process(image1, {
 				generators: names,
 			});
 			this._result = result1;
-			let res: any = result1.palettes;
+			const res: any = result1.palettes;
 			image.remove();
 			if (cb) {
 				cb(undefined, res);

--- a/packages/vibrant-core/src/pipeline/worker/client.ts
+++ b/packages/vibrant-core/src/pipeline/worker/client.ts
@@ -1,7 +1,9 @@
-import { Pipeline, ProcessOptions, ProcessResult } from "../index";
-import WorkerManager, { TaskWorkerClass } from "@vibrant/worker";
-import { Swatch, Palette } from "@vibrant/color";
+import { WorkerManager } from "@vibrant/worker";
+import { Swatch } from "@vibrant/color";
 import { mapValues } from "../../utils";
+import type { TaskWorkerClass } from "@vibrant/worker";
+import type { Palette } from "@vibrant/color";
+import type { Pipeline, ProcessOptions, ProcessResult } from "../index";
 
 /**
  * Client side (runs in UI thread)

--- a/packages/vibrant-generator-default/src/index.ts
+++ b/packages/vibrant-generator-default/src/index.ts
@@ -292,7 +292,7 @@ function _generateEmptySwatches(
 	}
 }
 
-const DefaultGenerator: Generator = ((
+export const DefaultGenerator: Generator = ((
 	swatches: Array<Swatch>,
 	opts?: DefaultGeneratorOptions,
 ): Palette => {
@@ -304,5 +304,3 @@ const DefaultGenerator: Generator = ((
 
 	return palette;
 }) as never;
-
-export default DefaultGenerator;

--- a/packages/vibrant-image-browser/__tests__/image.browser.spec.ts
+++ b/packages/vibrant-image-browser/__tests__/image.browser.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { loadTestSamples } from "../../../fixtures/sample/loader";
-import BrowserImage from "../src";
+import { BrowserImage } from "../src";
 
 const SAMPLES = loadTestSamples();
 

--- a/packages/vibrant-image-browser/src/index.ts
+++ b/packages/vibrant-image-browser/src/index.ts
@@ -27,7 +27,7 @@ function isSameOrigin(a: string, b: string): boolean {
 	);
 }
 
-export default class BrowserImage extends ImageBase {
+export class BrowserImage extends ImageBase {
 	image: HTMLImageElement | undefined;
 	private _canvas: HTMLCanvasElement | undefined;
 	private _context: CanvasRenderingContext2D | undefined;

--- a/packages/vibrant-image-node/src/index.ts
+++ b/packages/vibrant-image-node/src/index.ts
@@ -8,19 +8,11 @@ const Jimp = configure({
 	plugins: [resize],
 });
 
-interface ProtocalHandler {
-	get(url: string | any, cb?: (res: any) => void): any;
-}
-
-interface ProtocalHandlerMap {
-	[protocolName: string]: ProtocalHandler;
-}
-
 const URL_REGEX = /^(\w+):\/\/.*/i;
 
 type NodeImageSource = string | Buffer;
 
-export default class NodeImage extends ImageBase {
+export class NodeImage extends ImageBase {
 	private _image: InstanceType<typeof Jimp> | undefined;
 
 	private _getImage() {

--- a/packages/vibrant-quantizer-mmcq/src/index.ts
+++ b/packages/vibrant-quantizer-mmcq/src/index.ts
@@ -1,8 +1,9 @@
-import { Quantizer, QuantizerOptions } from "@vibrant/quantizer";
-import { Pixels } from "@vibrant/image";
+import { Quantizer } from "@vibrant/quantizer";
 import { Filter, Swatch } from "@vibrant/color";
-import VBox from "./vbox";
-import PQueue from "./pqueue";
+import { VBox } from "./vbox";
+import { PQueue } from "./pqueue";
+import type { Pixels } from "@vibrant/image";
+import type { QuantizerOptions } from "@vibrant/quantizer";
 
 const fractByPopulations = 0.75;
 
@@ -31,7 +32,7 @@ function _splitBoxes(pq: PQueue<VBox>, target: number): void {
 	}
 }
 
-const MMCQ = (pixels: Pixels, opts: QuantizerOptions): Array<Swatch> => {
+export const MMCQ = (pixels: Pixels, opts: QuantizerOptions): Array<Swatch> => {
 	if (pixels.length === 0 || opts.colorCount < 2 || opts.colorCount > 256) {
 		throw new Error("Wrong MMCQ parameters");
 	}
@@ -68,5 +69,3 @@ function generateSwatches(pq: PQueue<VBox>) {
 	}
 	return swatches;
 }
-
-export default MMCQ;

--- a/packages/vibrant-quantizer-mmcq/src/pqueue.ts
+++ b/packages/vibrant-quantizer-mmcq/src/pqueue.ts
@@ -2,7 +2,7 @@ interface PQueueComparator<T> {
 	(a: T, b: T): number;
 }
 
-export default class PQueue<T> {
+export class PQueue<T> {
 	contents: T[];
 	private _sorted: boolean;
 	private _comparator: PQueueComparator<T>;

--- a/packages/vibrant-quantizer-mmcq/src/vbox.ts
+++ b/packages/vibrant-quantizer-mmcq/src/vbox.ts
@@ -13,7 +13,7 @@ interface Dimension {
 const SIGBITS = 5;
 const RSHIFT = 8 - SIGBITS;
 
-export default class VBox {
+export class VBox {
 	static build(pixels: Pixels): VBox {
 		const h = new Histogram(pixels, { sigBits: SIGBITS });
 		const { rmin, rmax, gmin, gmax, bmin, bmax } = h;

--- a/packages/vibrant-worker/src/index.ts
+++ b/packages/vibrant-worker/src/index.ts
@@ -1,7 +1,7 @@
-import WorkerPool from "./pool";
-import { TaskWorkerClass } from "./common";
+import { WorkerPool } from "./pool";
+import type { TaskWorkerClass } from "./common";
 
-export default class WorkerManager {
+export class WorkerManager {
 	private _pools: { [name: string]: WorkerPool } = {};
 
 	register(name: string, WorkerClass: TaskWorkerClass) {

--- a/packages/vibrant-worker/src/pool.ts
+++ b/packages/vibrant-worker/src/pool.ts
@@ -15,7 +15,7 @@ interface Task<R> extends WorkerRequest {
 // const WorkerClass: TaskWorkerClass = require('worker-loader?inline=true!./worker')
 
 const MAX_WORKER_COUNT = 5;
-export default class WorkerPool {
+export class WorkerPool {
 	private _taskId = 0;
 
 	private _workers: TaskWorker[] = [];


### PR DESCRIPTION
This prevents us from:

- Making a breaking change in the future
- Making tree-shaking harder for those using our sub-packages
