### PR TITLE
Migrate to TypeScript 5, add backwards checks to 4.9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run lint
-npm run build
-npm run test

--- a/nx.json
+++ b/nx.json
@@ -2,14 +2,18 @@
 	"$schema": "./node_modules/nx/schemas/nx-schema.json",
 	"defaultBase": "v4",
 	"targetDefaults": {
-		"test:lib": {
-			"cache": true,
-			"dependsOn": ["^build"]
-		},
 		"build": {
 			"cache": true,
 			"dependsOn": ["^build"],
 			"outputs": ["{projectRoot}/dist"]
+		},
+		"test:lib": {
+			"cache": true,
+			"dependsOn": ["^build"]
+		},
+		"test:types": {
+			"cache": true,
+			"dependsOn": ["^build"]
 		},
 		"test:eslint": {
 			"cache": true,

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
 		"build": "lerna run build",
 		"prettier": "prettier --ignore-unknown .",
 		"prettier:write": "pnpm run prettier --write",
-		"test": "run-p -c test:*",
+		"test": "pnpm run  \"/^test:.*/\"",
 		"test:sherif": "sherif",
+		"test:knip": "knip",
 		"test:lib": "lerna run test:lib",
+		"test:types": "lerna run test:types",
 		"test:eslint": "lerna run test:eslint",
 		"test:format": "pnpm run prettier --check",
-		"test:knip": "knip",
 		"prepare": "husky install && playwright install chromium",
 		"do:publish": "lerna publish --no-private"
 	},
@@ -26,12 +27,15 @@
 		"knip": "^5.41.0",
 		"lerna": "^8.1.9",
 		"lint-staged": "^12.1.5",
-		"npm-run-all": "^4.1.5",
 		"playwright": "^1.49.1",
 		"prettier": "^3.4.2",
 		"sherif": "^1.1.1",
 		"table": "^5.2.0",
-		"typescript": "5.6.3"
+		"typescript": "5.6.3",
+		"typescript49": "npm:typescript@4.9",
+		"typescript53": "npm:typescript@5.3",
+		"typescript54": "npm:typescript@5.4",
+		"typescript55": "npm:typescript@5.5"
 	},
 	"lint-staged": {
 		"*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"prettier": "^3.4.2",
 		"sherif": "^1.1.1",
 		"table": "^5.2.0",
-		"typescript": "^4.5.2"
+		"typescript": "5.6.3"
 	},
 	"lint-staged": {
 		"*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"test:types": "lerna run test:types",
 		"test:eslint": "lerna run test:eslint",
 		"test:format": "pnpm run prettier --check",
-		"prepare": "husky install && playwright install chromium",
+		"prepare": "playwright install chromium",
 		"do:publish": "lerna publish --no-private"
 	},
 	"devDependencies": {
@@ -23,10 +23,8 @@
 		"@types/node": "^18.15.3",
 		"@types/table": "^4.0.5",
 		"eslint": "^9.17.0",
-		"husky": "^7.0.4",
 		"knip": "^5.41.0",
 		"lerna": "^8.1.9",
-		"lint-staged": "^12.1.5",
 		"playwright": "^1.49.1",
 		"prettier": "^3.4.2",
 		"sherif": "^1.1.1",
@@ -36,10 +34,5 @@
 		"typescript53": "npm:typescript@5.3",
 		"typescript54": "npm:typescript@5.4",
 		"typescript55": "npm:typescript@5.5"
-	},
-	"lint-staged": {
-		"*.{ts,tsx}": [
-			"eslint --fix"
-		]
 	}
 }

--- a/packages/node-vibrant/__tests__/common/helper.ts
+++ b/packages/node-vibrant/__tests__/common/helper.ts
@@ -22,16 +22,16 @@ const assertPalette = (reference: Palette, palette: Palette) => {
 	let failCount = 0;
 	const compare = (
 		name: string,
-		expected: Swatch | null,
-		actual: Swatch | null,
+		expected: Swatch | undefined | null,
+		actual: Swatch | undefined | null,
 	) => {
 		const result = {
 			status: "N/A",
 			diff: -1,
 		};
 
-		if (expected === null) {
-			if (actual !== null) {
+		if (!expected) {
+			if (actual) {
 				console.warn(`WARN: ${name} color was not expected. Got ${actual.hex}`);
 			}
 		} else {
@@ -53,8 +53,8 @@ const assertPalette = (reference: Palette, palette: Palette) => {
 	const expectedRow = ["Expected"];
 	const scoreRow = ["Score"];
 	for (const name of names) {
-		const actual = palette[name]!;
-		const expected = reference[name]!;
+		const actual = palette[name];
+		const expected = reference[name];
 		actualRow.push(actual ? actual.hex : "null");
 		expectedRow.push(expected ? util.rgbToHex(...expected.rgb) : "null");
 		const r = compare(name, expected, actual);

--- a/packages/node-vibrant/__tests__/common/helper.ts
+++ b/packages/node-vibrant/__tests__/common/helper.ts
@@ -53,8 +53,8 @@ const assertPalette = (reference: Palette, palette: Palette) => {
 	const expectedRow = ["Expected"];
 	const scoreRow = ["Score"];
 	for (const name of names) {
-		const actual = palette[name];
-		const expected = reference[name];
+		const actual = palette[name]!;
+		const expected = reference[name]!;
 		actualRow.push(actual ? actual.hex : "null");
 		expectedRow.push(expected ? util.rgbToHex(...expected.rgb) : "null");
 		const r = compare(name, expected, actual);
@@ -73,10 +73,11 @@ const assertPalette = (reference: Palette, palette: Palette) => {
 };
 
 const paletteCallback =
-	(references: any, done: () => void) => (err: Error, palette: Palette) => {
+	(references: any, done: () => void) =>
+	(err: Error | undefined, palette: Palette | undefined) => {
 		setTimeout(() => {
 			expect(err, `should not throw error '${err}'`).to.be.undefined;
-			assertPalette(references, palette);
+			assertPalette(references, palette!);
 
 			done();
 		});
@@ -120,6 +121,6 @@ export const testVibrantAsPromised = (
 
 		const palette = await builder.getPalette();
 
-		assertPalette(sample.palettes[env], palette);
+		assertPalette(sample.palettes[env]!, palette);
 	};
 };

--- a/packages/node-vibrant/__tests__/vibrant.node.spec.ts
+++ b/packages/node-vibrant/__tests__/vibrant.node.spec.ts
@@ -12,7 +12,7 @@ const TEST_PORT = 3444;
 
 const SAMPLES = loadTestSamples(TEST_PORT);
 
-let server: http.Server | null = null;
+let server!: http.Server;
 
 beforeAll(async () => {
 	server = createSampleServer();

--- a/packages/node-vibrant/package.json
+++ b/packages/node-vibrant/package.json
@@ -67,7 +67,6 @@
 		"@vibrant/color": "^4.0.0-alpha.4",
 		"@vitest/browser": "^2.1.8",
 		"playwright": "^1.49.1",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3",
 		"vitest": "^2.1.8"
 	},

--- a/packages/node-vibrant/package.json
+++ b/packages/node-vibrant/package.json
@@ -74,7 +74,13 @@
 		"build": "vite build",
 		"test:lib": "vitest run",
 		"test:lib:watch": "vitest watch",
-		"test:eslint": "eslint ./src ./__tests__"
+		"test:eslint": "eslint ./src ./__tests__",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"bugs": {
 		"url": "https://github.com/akfish/node-vibrant/issues"

--- a/packages/node-vibrant/vite.config.ts
+++ b/packages/node-vibrant/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({

--- a/packages/node-vibrant/vitest.workspace.ts
+++ b/packages/node-vibrant/vitest.workspace.ts
@@ -7,22 +7,22 @@ import http from "http";
 
 const TEST_PORT = 4555;
 
-const loadSamples: BrowserCommand<never> = ({}) => {
+const loadSamples: BrowserCommand<never[]> = ({}) => {
 	const SAMPLES = loadTestSamples(TEST_PORT);
 	return SAMPLES;
 };
 
 let server: http.Server | null = null;
 
-const startServer: BrowserCommand<never> = async ({}) => {
+const startServer: BrowserCommand<never[]> = async ({}) => {
 	server = createSampleServer();
 	await new Promise<void>((resolve) =>
-		server.listen(TEST_PORT, () => resolve()),
+		server!.listen(TEST_PORT, () => resolve()),
 	);
 	return null;
 };
 
-const stopServer: BrowserCommand<never> = async ({}) =>
+const stopServer: BrowserCommand<never[]> = async ({}) =>
 	new Promise<void>((resolve, reject) =>
 		server!.close((err) => {
 			if (err) return reject(err);

--- a/packages/vibrant-color/package.json
+++ b/packages/vibrant-color/package.json
@@ -4,7 +4,13 @@
 	"description": "Color utilities for vibrant",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-color/package.json
+++ b/packages/vibrant-color/package.json
@@ -39,7 +39,6 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-color/vite.config.ts
+++ b/packages/vibrant-color/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-core/package.json
+++ b/packages/vibrant-core/package.json
@@ -49,7 +49,6 @@
 	},
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3",
 		"vitest": "^2.1.8"
 	},

--- a/packages/vibrant-core/package.json
+++ b/packages/vibrant-core/package.json
@@ -6,7 +6,13 @@
 		"test:lib": "vitest run",
 		"test:lib:watch": "vitest watch",
 		"build": "vite build",
-		"test:eslint": "eslint ./src ./__tests__"
+		"test:eslint": "eslint ./src ./__tests__",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-core/vite.config.ts
+++ b/packages/vibrant-core/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-generator-default/package.json
+++ b/packages/vibrant-generator-default/package.json
@@ -4,7 +4,13 @@
 	"description": "Default generator that generates the original vibrant palette",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-generator-default/package.json
+++ b/packages/vibrant-generator-default/package.json
@@ -43,9 +43,6 @@
 		"@vibrant/generator": "^4.0.0-alpha.4",
 		"vite": "^6.0.3"
 	},
-	"devDependencies": {
-		"typescript": "^4.5.2"
-	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/vibrant-generator-default/vite.config.ts
+++ b/packages/vibrant-generator-default/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-generator/package.json
+++ b/packages/vibrant-generator/package.json
@@ -4,7 +4,13 @@
 	"description": "Helpers and typings for writing a vibrant generator",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-generator/package.json
+++ b/packages/vibrant-generator/package.json
@@ -43,7 +43,6 @@
 	},
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-generator/vite.config.ts
+++ b/packages/vibrant-generator/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-image-browser/__tests__/image.browser.spec.ts
+++ b/packages/vibrant-image-browser/__tests__/image.browser.spec.ts
@@ -7,7 +7,7 @@ const SAMPLES = loadTestSamples();
 describe.skip("Browser Image", () => {
 	const loc = window.location;
 	const CROS_URL = "https://avatars3.githubusercontent.com/u/922715?v=3&s=460";
-	const RELATIVE_URL = SAMPLES[0].relativeUrl;
+	const RELATIVE_URL = SAMPLES[0]!.relativeUrl;
 	const SAME_ORIGIN_URL = `${loc.protocol}//${loc.host}/${RELATIVE_URL}`;
 
 	it.skip("should set crossOrigin flag for images form foreign origin", async () => {
@@ -37,7 +37,7 @@ describe.skip("Browser Image", () => {
 
 	it("should accept HTMLImageElement as input", async () => {
 		const img = document.createElement("img");
-		img.src = SAMPLES[0].relativeUrl;
+		img.src = SAMPLES[0]!.relativeUrl;
 
 		const m1 = new BrowserImage();
 		await m1.load(img);
@@ -45,13 +45,13 @@ describe.skip("Browser Image", () => {
 
 	it("should accept HTMLImageElement that is already loaded as input", async () => {
 		const img = document.createElement("img");
-		img.src = SAMPLES[0].relativeUrl;
+		img.src = SAMPLES[0]!.relativeUrl;
 
 		let resolve = () => {};
 		const prom = new Promise<void>((r) => (resolve = r));
 		img.onload = () => {
-			const tslintm1 = new BrowserImage();
-			m1.load(img).then((img) => resolve());
+			const m1 = new BrowserImage();
+			m1.load(img).then(() => resolve());
 		};
 
 		await prom;

--- a/packages/vibrant-image-browser/package.json
+++ b/packages/vibrant-image-browser/package.json
@@ -6,7 +6,13 @@
 		"build": "vite build",
 		"test:lib": "vitest run",
 		"test:lib:watch": "vitest watch",
-		"test:eslint": "eslint ./src ./__tests__"
+		"test:eslint": "eslint ./src ./__tests__",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-image-browser/package.json
+++ b/packages/vibrant-image-browser/package.json
@@ -46,7 +46,6 @@
 		"@tanstack/config": "^0.14.2",
 		"@types/node": "^18.15.3",
 		"jsdom": "^25.0.1",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3",
 		"vitest": "^2.1.8"
 	},

--- a/packages/vibrant-image-browser/vite.config.ts
+++ b/packages/vibrant-image-browser/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-image-node/package.json
+++ b/packages/vibrant-image-node/package.json
@@ -46,7 +46,6 @@
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
 		"@types/node": "^18.15.3",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-image-node/package.json
+++ b/packages/vibrant-image-node/package.json
@@ -4,7 +4,13 @@
 	"description": "Node.js vibrant ImageClass implementation",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-image-node/vite.config.ts
+++ b/packages/vibrant-image-node/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-image/package.json
+++ b/packages/vibrant-image/package.json
@@ -4,7 +4,13 @@
 	"description": "Helpers and typings for writing a vibrant ImageClass",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-image/package.json
+++ b/packages/vibrant-image/package.json
@@ -44,7 +44,6 @@
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
 		"@types/node": "^18.15.3",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-image/src/histogram.ts
+++ b/packages/vibrant-image/src/histogram.ts
@@ -61,6 +61,7 @@ export class Histogram {
 			b = b >> rshift;
 
 			const index = getColorIndex(r, g, b);
+			if (hist[index] === undefined) hist[index] = 0;
 			hist[index] += 1;
 
 			if (r > rmax) rmax = r;

--- a/packages/vibrant-image/vite.config.ts
+++ b/packages/vibrant-image/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-quantizer-mmcq/package.json
+++ b/packages/vibrant-quantizer-mmcq/package.json
@@ -44,7 +44,6 @@
 	},
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-quantizer-mmcq/package.json
+++ b/packages/vibrant-quantizer-mmcq/package.json
@@ -4,7 +4,13 @@
 	"description": "MMCQ quantzier for vibrant",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-quantizer-mmcq/vite.config.ts
+++ b/packages/vibrant-quantizer-mmcq/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-quantizer/package.json
+++ b/packages/vibrant-quantizer/package.json
@@ -44,7 +44,6 @@
 	},
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-quantizer/package.json
+++ b/packages/vibrant-quantizer/package.json
@@ -4,7 +4,13 @@
 	"description": "Helper and typings for writing a vibrant quantizer",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-quantizer/vite.config.ts
+++ b/packages/vibrant-quantizer/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-types/package.json
+++ b/packages/vibrant-types/package.json
@@ -4,7 +4,13 @@
 	"description": "Common typings for vibrant",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"type": "module",
 	"types": "dist/esm/index.d.ts",

--- a/packages/vibrant-types/package.json
+++ b/packages/vibrant-types/package.json
@@ -39,7 +39,6 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-types/vite.config.ts
+++ b/packages/vibrant-types/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/packages/vibrant-worker/package.json
+++ b/packages/vibrant-worker/package.json
@@ -4,7 +4,13 @@
 	"description": "Web worker utilities",
 	"scripts": {
 		"build": "vite build",
-		"test:eslint": "eslint ./src"
+		"test:eslint": "eslint ./src",
+		"test:types": "pnpm run \"/^test:types:ts[0-9]{2}$/\"",
+		"test:types:ts49": "node ../../node_modules/typescript49/lib/tsc.js",
+		"test:types:ts53": "node ../../node_modules/typescript53/lib/tsc.js",
+		"test:types:ts54": "node ../../node_modules/typescript54/lib/tsc.js",
+		"test:types:ts55": "node ../../node_modules/typescript55/lib/tsc.js",
+		"test:types:ts56": "tsc"
 	},
 	"author": {
 		"name": "akfish",

--- a/packages/vibrant-worker/package.json
+++ b/packages/vibrant-worker/package.json
@@ -42,7 +42,6 @@
 	},
 	"devDependencies": {
 		"@tanstack/config": "^0.14.2",
-		"typescript": "^4.5.2",
 		"vite": "^6.0.3"
 	},
 	"publishConfig": {

--- a/packages/vibrant-worker/vite.config.ts
+++ b/packages/vibrant-worker/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from "vite";
+// @ts-ignore
 import { tanstackViteConfig } from "@tanstack/config/vite";
 
 const config = defineConfig({});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,18 +20,12 @@ importers:
       eslint:
         specifier: ^9.17.0
         version: 9.17.0(jiti@2.4.1)
-      husky:
-        specifier: ^7.0.4
-        version: 7.0.4
       knip:
         specifier: ^5.41.0
         version: 5.41.0(@types/node@18.19.68)(typescript@5.6.3)
       lerna:
         specifier: ^8.1.9
         version: 8.1.9(encoding@0.1.13)
-      lint-staged:
-        specifier: ^12.1.5
-        version: 12.5.0(enquirer@2.3.6)
       playwright:
         specifier: ^1.49.1
         version: 1.49.1
@@ -1588,10 +1582,6 @@ packages:
     resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
     engines: {node: '>=4'}
 
-  astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
-
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -1714,14 +1704,6 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
-  cli-truncate@2.1.0:
-    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
-    engines: {node: '>=8'}
-
-  cli-truncate@3.1.0:
-    resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
@@ -1766,9 +1748,6 @@ packages:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
 
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
   columnify@1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
     engines: {node: '>=8.0.0'}
@@ -1787,10 +1766,6 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-
-  commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
-    engines: {node: ^12.20.0 || >=14}
 
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
@@ -2209,10 +2184,6 @@ packages:
     resolution: {integrity: sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==}
     engines: {node: '>=10'}
 
-  execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
-
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
@@ -2396,10 +2367,6 @@ packages:
     resolution: {integrity: sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==}
     engines: {node: '>=10'}
 
-  get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
 
@@ -2543,11 +2510,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  husky@7.0.4:
-    resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -2649,10 +2611,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
-    engines: {node: '>=12'}
-
   is-git-repository@1.1.1:
     resolution: {integrity: sha512-hxLpJytJnIZ5Og5QsxSkzmb8Qx8rGau9bio1JN/QtXcGEFuSsQYau0IiqlsCwftsfVYjF1mOq6uLdmwNSspgpA==}
 
@@ -2706,10 +2664,6 @@ packages:
 
   is-stream@2.0.0:
     resolution: {integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==}
-    engines: {node: '>=8'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
   is-text-path@1.0.1:
@@ -2893,10 +2847,6 @@ packages:
     resolution: {integrity: sha512-a5BQjbCHnB+cy+gsro8lXJ4kZluzOijzJ1UVVfyJYZC+IP2pLv1h4+aysQeKuTmyO8NAqfyQAk4HWaP/HjcKTg==}
     engines: {node: '>=10.13.0'}
 
-  lilconfig@2.0.5:
-    resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}
-    engines: {node: '>=10'}
-
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2906,20 +2856,6 @@ packages:
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
-
-  lint-staged@12.5.0:
-    resolution: {integrity: sha512-BKLUjWDsKquV/JuIcoQW4MSAI3ggwEImF1+sB4zaKvyVx1wBk3FsG7UK9bpnmBTN1pm7EH2BBcMwINJzCRv12g==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-
-  listr2@4.0.5:
-    resolution: {integrity: sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      enquirer: '>= 2.3.0 < 3'
-    peerDependenciesMeta:
-      enquirer:
-        optional: true
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -2956,10 +2892,6 @@ packages:
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
-
-  log-update@4.0.0:
-    resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
     engines: {node: '>=10'}
 
   loupe@3.1.2:
@@ -3223,10 +3155,6 @@ packages:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
   npm-bundled@3.0.1:
     resolution: {integrity: sha512-+AvaheE/ww1JEwRHOrn4WHNzOxGtVp+adrg2AeZS/7KuxGUYFuBta98wYpfHBbJp6Tg6j1NKSEVHNcfZzJHQwQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3277,10 +3205,6 @@ packages:
         optional: true
       '@swc/core':
         optional: true
-
-  object-inspect@1.13.3:
-    resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
-    engines: {node: '>= 0.4'}
 
   object.defaults@1.1.0:
     resolution: {integrity: sha512-c/K0mw/F11k4dEUBMW8naXUuBuhxRCfG7W+yFy8EcijU/rSmazOUd1XAEEe6bC0OuXY4HUKjTJv7xbxIMqdxrA==}
@@ -3513,11 +3437,6 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
-
-  pidtree@0.5.0:
-    resolution: {integrity: sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -3765,9 +3684,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
   rimraf@4.4.1:
     resolution: {integrity: sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==}
     engines: {node: '>=14'}
@@ -3919,18 +3835,6 @@ packages:
   slice-ansi@2.1.0:
     resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
     engines: {node: '>=6'}
-
-  slice-ansi@3.0.0:
-    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
-    engines: {node: '>=8'}
-
-  slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
-
-  slice-ansi@5.0.0:
-    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
-    engines: {node: '>=12'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -4092,10 +3996,6 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
-
-  supports-color@9.4.0:
-    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
-    engines: {node: '>=12'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -4665,10 +4565,6 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
-
   yaml@2.6.1:
     resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
     engines: {node: '>= 14'}
@@ -4924,7 +4820,7 @@ snapshots:
   '@eslint/config-array@0.19.1':
     dependencies:
       '@eslint/object-schema': 2.1.5
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4936,7 +4832,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5114,7 +5010,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5836,7 +5732,7 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.18.0
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       eslint: 9.17.0(jiti@2.4.1)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -5851,7 +5747,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
       '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       eslint: 9.17.0(jiti@2.4.1)
       ts-api-utils: 1.4.3(typescript@5.6.3)
       typescript: 5.6.3
@@ -5864,7 +5760,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6124,8 +6020,6 @@ snapshots:
 
   astral-regex@1.0.0: {}
 
-  astral-regex@2.0.0: {}
-
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -6250,16 +6144,6 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
-  cli-truncate@2.1.0:
-    dependencies:
-      slice-ansi: 3.0.0
-      string-width: 4.2.3
-
-  cli-truncate@3.1.0:
-    dependencies:
-      slice-ansi: 5.0.0
-      string-width: 5.1.2
-
   cli-width@3.0.0: {}
 
   cli-width@4.1.0: {}
@@ -6300,8 +6184,6 @@ snapshots:
 
   color-support@1.1.3: {}
 
-  colorette@2.0.20: {}
-
   columnify@1.6.0:
     dependencies:
       strip-ansi: 6.0.1
@@ -6317,8 +6199,6 @@ snapshots:
     optional: true
 
   commander@4.1.1: {}
-
-  commander@9.5.0: {}
 
   common-ancestor-path@1.0.1: {}
 
@@ -6459,11 +6339,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.0(supports-color@9.4.0):
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 9.4.0
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -6582,7 +6460,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.24.0):
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       esbuild: 0.24.0
     transitivePeerDependencies:
       - supports-color
@@ -6672,7 +6550,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/scope-manager': 8.18.0
       '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       doctrine: 3.0.0
       eslint: 9.17.0(jiti@2.4.1)
       eslint-import-resolver-node: 0.3.9
@@ -6724,7 +6602,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -6794,18 +6672,6 @@ snapshots:
       get-stream: 6.0.0
       human-signals: 2.1.0
       is-stream: 2.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-
-  execa@5.1.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
@@ -6994,8 +6860,6 @@ snapshots:
 
   get-stream@6.0.0: {}
 
-  get-stream@6.0.1: {}
-
   get-tsconfig@4.8.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -7147,20 +7011,18 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   human-signals@2.1.0: {}
-
-  husky@7.0.4: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -7264,8 +7126,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@4.0.0: {}
-
   is-git-repository@1.1.1:
     dependencies:
       execa: 0.6.3
@@ -7306,8 +7166,6 @@ snapshots:
   is-stream@1.1.0: {}
 
   is-stream@2.0.0: {}
-
-  is-stream@2.0.1: {}
 
   is-text-path@1.0.1:
     dependencies:
@@ -7607,8 +7465,6 @@ snapshots:
       rechoir: 0.8.0
       resolve: 1.22.9
 
-  lilconfig@2.0.5: {}
-
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.3: {}
@@ -7616,38 +7472,6 @@ snapshots:
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
-
-  lint-staged@12.5.0(enquirer@2.3.6):
-    dependencies:
-      cli-truncate: 3.1.0
-      colorette: 2.0.20
-      commander: 9.5.0
-      debug: 4.4.0(supports-color@9.4.0)
-      execa: 5.1.1
-      lilconfig: 2.0.5
-      listr2: 4.0.5(enquirer@2.3.6)
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-inspect: 1.13.3
-      pidtree: 0.5.0
-      string-argv: 0.3.2
-      supports-color: 9.4.0
-      yaml: 1.10.2
-    transitivePeerDependencies:
-      - enquirer
-
-  listr2@4.0.5(enquirer@2.3.6):
-    dependencies:
-      cli-truncate: 2.1.0
-      colorette: 2.0.20
-      log-update: 4.0.0
-      p-map: 4.0.0
-      rfdc: 1.4.1
-      rxjs: 7.8.1
-      through: 2.3.8
-      wrap-ansi: 7.0.0
-    optionalDependencies:
-      enquirer: 2.3.6
 
   load-json-file@4.0.0:
     dependencies:
@@ -7691,13 +7515,6 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-
-  log-update@4.0.0:
-    dependencies:
-      ansi-escapes: 4.3.2
-      cli-cursor: 3.1.0
-      slice-ansi: 4.0.0
-      wrap-ansi: 6.2.0
 
   loupe@3.1.2: {}
 
@@ -7984,8 +7801,6 @@ snapshots:
       semver: 7.6.3
       validate-npm-package-license: 3.0.4
 
-  normalize-path@3.0.0: {}
-
   npm-bundled@3.0.1:
     dependencies:
       npm-normalize-package-bin: 3.0.1
@@ -8085,8 +7900,6 @@ snapshots:
       '@nx/nx-win32-x64-msvc': 20.2.2
     transitivePeerDependencies:
       - debug
-
-  object-inspect@1.13.3: {}
 
   object.defaults@1.1.0:
     dependencies:
@@ -8326,8 +8139,6 @@ snapshots:
 
   picomatch@4.0.2: {}
 
-  pidtree@0.5.0: {}
-
   pify@2.3.0: {}
 
   pify@3.0.0: {}
@@ -8544,8 +8355,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rfdc@1.4.1: {}
-
   rimraf@4.4.1:
     dependencies:
       glob: 9.3.5
@@ -8706,7 +8515,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8724,23 +8533,6 @@ snapshots:
       astral-regex: 1.0.0
       is-fullwidth-code-point: 2.0.0
 
-  slice-ansi@3.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-
-  slice-ansi@4.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-
-  slice-ansi@5.0.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      is-fullwidth-code-point: 4.0.0
-
   smart-buffer@4.2.0: {}
 
   smol-toml@1.3.1: {}
@@ -8748,7 +8540,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -8891,8 +8683,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-color@9.4.0: {}
-
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
@@ -9023,7 +8813,7 @@ snapshots:
   tuf-js@2.2.1:
     dependencies:
       '@tufjs/models': 2.0.1
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       make-fetch-happen: 13.0.1
     transitivePeerDependencies:
       - supports-color
@@ -9144,7 +8934,7 @@ snapshots:
   vite-node@2.1.8(@types/node@18.19.68)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       es-module-lexer: 1.5.4
       pathe: 1.1.2
       vite: 5.4.11(@types/node@18.19.68)(terser@5.37.0)
@@ -9166,7 +8956,7 @@ snapshots:
       '@volar/typescript': 2.4.11
       '@vue/language-core': 2.0.29(typescript@5.6.3)
       compare-versions: 6.1.1
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.15
@@ -9185,7 +8975,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.6.3)
     optionalDependencies:
@@ -9226,7 +9016,7 @@ snapshots:
       '@vitest/spy': 2.1.8
       '@vitest/utils': 2.1.8
       chai: 5.1.2
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.15
       pathe: 1.1.2
@@ -9378,8 +9168,6 @@ snapshots:
   yallist@2.1.2: {}
 
   yallist@4.0.0: {}
-
-  yaml@1.10.2: {}
 
   yaml@2.6.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/node':
         specifier: ^18.15.3
         version: 18.19.68
@@ -25,7 +25,7 @@ importers:
         version: 7.0.4
       knip:
         specifier: ^5.41.0
-        version: 5.41.0(@types/node@18.19.68)(typescript@4.9.5)
+        version: 5.41.0(@types/node@18.19.68)(typescript@5.6.3)
       lerna:
         specifier: ^8.1.9
         version: 8.1.9(encoding@0.1.13)
@@ -48,8 +48,8 @@ importers:
         specifier: ^5.2.0
         version: 5.4.6
       typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        specifier: 5.6.3
+        version: 5.6.3
 
   fixtures/sample:
     dependencies:
@@ -93,34 +93,28 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@vibrant/color':
         specifier: ^4.0.0-alpha.4
         version: link:../vibrant-color
       '@vitest/browser':
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)
+        version: 2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)
       playwright:
         specifier: ^1.49.1
         version: 1.49.1
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(terser@5.37.0)
+        version: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(terser@5.37.0)
 
   packages/vibrant-color:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -148,16 +142,13 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(terser@5.37.0)
+        version: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(terser@5.37.0)
 
   packages/vibrant-generator:
     dependencies:
@@ -170,10 +161,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -182,7 +170,7 @@ importers:
     dependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@vibrant/color':
         specifier: ^4.0.0-alpha.4
         version: link:../vibrant-color
@@ -192,10 +180,6 @@ importers:
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
-    devDependencies:
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
 
   packages/vibrant-image:
     dependencies:
@@ -208,13 +192,10 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/node':
         specifier: ^18.15.3
         version: 18.19.68
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -227,22 +208,19 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/node':
         specifier: ^18.15.3
         version: 18.19.68
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(terser@5.37.0)
+        version: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(terser@5.37.0)
 
   packages/vibrant-image-node:
     dependencies:
@@ -261,13 +239,10 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@types/node':
         specifier: ^18.15.3
         version: 18.19.68
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -286,10 +261,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -308,10 +280,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -320,10 +289,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -336,10 +302,7 @@ importers:
     devDependencies:
       '@tanstack/config':
         specifier: ^0.14.2
-        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      typescript:
-        specifier: ^4.5.2
-        version: 4.9.5
+        version: 0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
@@ -4674,6 +4637,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -6055,7 +6023,7 @@ snapshots:
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
 
-  '@tanstack/config@0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
+  '@tanstack/config@0.14.2(@types/node@18.19.68)(esbuild@0.24.0)(eslint@9.17.0(jiti@2.4.1))(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@commitlint/parse': 19.5.0
       '@eslint/js': 9.17.0
@@ -6063,7 +6031,7 @@ snapshots:
       commander: 12.1.0
       current-git-branch: 1.1.0
       esbuild-register: 3.6.0(esbuild@0.24.0)
-      eslint-plugin-import-x: 4.5.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      eslint-plugin-import-x: 4.5.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       eslint-plugin-n: 17.15.0(eslint@9.17.0(jiti@2.4.1))
       globals: 15.13.0
       interpret: 3.1.1
@@ -6073,14 +6041,14 @@ snapshots:
       rollup-plugin-preserve-directives: 0.4.0(rollup@4.28.1)
       semver: 7.6.3
       simple-git: 3.27.0
-      typedoc: 0.27.5(typescript@4.9.5)
-      typedoc-plugin-frontmatter: 1.1.2(typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@4.9.5)))
-      typedoc-plugin-markdown: 4.3.2(typedoc@0.27.5(typescript@4.9.5))
-      typescript-eslint: 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      typedoc: 0.27.5(typescript@5.6.3)
+      typedoc-plugin-frontmatter: 1.1.2(typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@5.6.3)))
+      typedoc-plugin-markdown: 4.3.2(typedoc@0.27.5(typescript@5.6.3))
+      typescript-eslint: 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       v8flags: 4.0.1
-      vite-plugin-dts: 4.0.3(@types/node@18.19.68)(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+      vite-plugin-dts: 4.0.3(@types/node@18.19.68)(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       vite-plugin-externalize-deps: 0.8.0(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
-      vite-tsconfig-paths: 5.1.4(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+      vite-tsconfig-paths: 5.1.4(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
     transitivePeerDependencies:
       - '@types/node'
       - esbuild
@@ -6177,32 +6145,32 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5))(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3))(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.18.0
-      '@typescript-eslint/type-utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.18.0
       eslint: 9.17.0(jiti@2.4.1)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 1.4.3(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)':
+  '@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.18.0
       '@typescript-eslint/types': 8.18.0
-      '@typescript-eslint/typescript-estree': 8.18.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.18.0
       debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.17.0(jiti@2.4.1)
-      typescript: 4.9.5
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6211,20 +6179,20 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
 
-  '@typescript-eslint/type-utils@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.18.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       debug: 4.4.0(supports-color@9.4.0)
       eslint: 9.17.0(jiti@2.4.1)
-      ts-api-utils: 1.4.3(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 1.4.3(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.18.0': {}
 
-  '@typescript-eslint/typescript-estree@8.18.0(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@8.18.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
@@ -6233,19 +6201,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.4.3(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 1.4.3(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)':
+  '@typescript-eslint/utils@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.1))
       '@typescript-eslint/scope-manager': 8.18.0
       '@typescript-eslint/types': 8.18.0
-      '@typescript-eslint/typescript-estree': 8.18.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.6.3)
       eslint: 9.17.0(jiti@2.4.1)
-      typescript: 4.9.5
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6254,17 +6222,17 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/browser@2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)':
+  '@vitest/browser@2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
+      '@vitest/mocker': 2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))
       '@vitest/utils': 2.1.8
       magic-string: 0.30.15
-      msw: 2.6.8(@types/node@18.19.68)(typescript@4.9.5)
+      msw: 2.6.8(@types/node@18.19.68)(typescript@5.6.3)
       sirv: 3.0.0
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(terser@5.37.0)
+      vitest: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(terser@5.37.0)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.49.1
@@ -6282,22 +6250,22 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))':
+  '@vitest/mocker@2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.15
     optionalDependencies:
-      msw: 2.6.8(@types/node@18.19.68)(typescript@4.9.5)
+      msw: 2.6.8(@types/node@18.19.68)(typescript@5.6.3)
       vite: 5.4.11(@types/node@18.19.68)(terser@5.37.0)
 
-  '@vitest/mocker@2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
+  '@vitest/mocker@2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.15
     optionalDependencies:
-      msw: 2.6.8(@types/node@18.19.68)(typescript@4.9.5)
+      msw: 2.6.8(@types/node@18.19.68)(typescript@5.6.3)
       vite: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
 
   '@vitest/pretty-format@2.1.8':
@@ -6355,7 +6323,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.0.29(typescript@4.9.5)':
+  '@vue/language-core@2.0.29(typescript@5.6.3)':
     dependencies:
       '@volar/language-core': 2.4.11
       '@vue/compiler-dom': 3.5.13
@@ -6366,7 +6334,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.6.3
 
   '@vue/shared@3.5.13': {}
 
@@ -7188,10 +7156,10 @@ snapshots:
       eslint: 9.17.0(jiti@2.4.1)
       eslint-compat-utils: 0.5.1(eslint@9.17.0(jiti@2.4.1))
 
-  eslint-plugin-import-x@4.5.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5):
+  eslint-plugin-import-x@4.5.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.18.0
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       debug: 4.4.0(supports-color@9.4.0)
       doctrine: 3.0.0
       eslint: 9.17.0(jiti@2.4.1)
@@ -8129,7 +8097,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  knip@5.41.0(@types/node@18.19.68)(typescript@4.9.5):
+  knip@5.41.0(@types/node@18.19.68)(typescript@5.6.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@snyk/github-codeowners': 1.1.0
@@ -8146,7 +8114,7 @@ snapshots:
       smol-toml: 1.3.1
       strip-json-comments: 5.0.1
       summary: 2.1.0
-      typescript: 4.9.5
+      typescript: 5.6.3
       zod: 3.24.1
       zod-validation-error: 3.4.0(zod@3.24.1)
 
@@ -8564,7 +8532,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5):
+  msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -8585,7 +8553,7 @@ snapshots:
       type-fest: 4.30.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.6.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -9819,13 +9787,13 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@1.4.3(typescript@4.9.5):
+  ts-api-utils@1.4.3(typescript@5.6.3):
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.6.3
 
-  tsconfck@3.1.4(typescript@4.9.5):
+  tsconfck@3.1.4(typescript@5.6.3):
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.6.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -9894,37 +9862,39 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-frontmatter@1.1.2(typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@4.9.5))):
+  typedoc-plugin-frontmatter@1.1.2(typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@5.6.3))):
     dependencies:
-      typedoc-plugin-markdown: 4.3.2(typedoc@0.27.5(typescript@4.9.5))
+      typedoc-plugin-markdown: 4.3.2(typedoc@0.27.5(typescript@5.6.3))
       yaml: 2.6.1
 
-  typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@4.9.5)):
+  typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@5.6.3)):
     dependencies:
-      typedoc: 0.27.5(typescript@4.9.5)
+      typedoc: 0.27.5(typescript@5.6.3)
 
-  typedoc@0.27.5(typescript@4.9.5):
+  typedoc@0.27.5(typescript@5.6.3):
     dependencies:
       '@gerrit0/mini-shiki': 1.24.4
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
-      typescript: 4.9.5
+      typescript: 5.6.3
       yaml: 2.6.1
 
-  typescript-eslint@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5):
+  typescript-eslint@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5))(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.18.0(@typescript-eslint/parser@8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3))(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@2.4.1))(typescript@5.6.3)
       eslint: 9.17.0(jiti@2.4.1)
-      typescript: 4.9.5
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@4.9.5: {}
 
   typescript@5.4.2: {}
+
+  typescript@5.6.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -10008,19 +9978,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@4.0.3(@types/node@18.19.68)(rollup@4.28.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)):
+  vite-plugin-dts@4.0.3(@types/node@18.19.68)(rollup@4.28.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
       '@microsoft/api-extractor': 7.47.4(@types/node@18.19.68)
       '@rollup/pluginutils': 5.1.3(rollup@4.28.1)
       '@volar/typescript': 2.4.11
-      '@vue/language-core': 2.0.29(typescript@4.9.5)
+      '@vue/language-core': 2.0.29(typescript@5.6.3)
       compare-versions: 6.1.1
       debug: 4.4.0(supports-color@9.4.0)
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.15
-      typescript: 4.9.5
-      vue-tsc: 2.0.29(typescript@4.9.5)
+      typescript: 5.6.3
+      vue-tsc: 2.0.29(typescript@5.6.3)
     optionalDependencies:
       vite: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
@@ -10032,11 +10002,11 @@ snapshots:
     dependencies:
       vite: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
 
-  vite-tsconfig-paths@5.1.4(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)):
     dependencies:
       debug: 4.4.0(supports-color@9.4.0)
       globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@4.9.5)
+      tsconfck: 3.1.4(typescript@5.6.3)
     optionalDependencies:
       vite: 6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1)
     transitivePeerDependencies:
@@ -10065,10 +10035,10 @@ snapshots:
       terser: 5.37.0
       yaml: 2.6.1
 
-  vitest@2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(terser@5.37.0):
+  vitest@2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(jsdom@25.0.1)(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@4.9.5))(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))
+      '@vitest/mocker': 2.1.8(msw@2.6.8(@types/node@18.19.68)(typescript@5.6.3))(vite@5.4.11(@types/node@18.19.68)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -10089,7 +10059,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.68
-      '@vitest/browser': 2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@4.9.5)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)
+      '@vitest/browser': 2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@5.6.3)(vite@6.0.3(@types/node@18.19.68)(jiti@2.4.1)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less
@@ -10104,12 +10074,12 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-tsc@2.0.29(typescript@4.9.5):
+  vue-tsc@2.0.29(typescript@5.6.3):
     dependencies:
       '@volar/typescript': 2.4.11
-      '@vue/language-core': 2.0.29(typescript@4.9.5)
+      '@vue/language-core': 2.0.29(typescript@5.6.3)
       semver: 7.6.3
-      typescript: 4.9.5
+      typescript: 5.6.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       lint-staged:
         specifier: ^12.1.5
         version: 12.5.0(enquirer@2.3.6)
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
       playwright:
         specifier: ^1.49.1
         version: 1.49.1
@@ -50,6 +47,18 @@ importers:
       typescript:
         specifier: 5.6.3
         version: 5.6.3
+      typescript49:
+        specifier: npm:typescript@4.9
+        version: typescript@4.9.5
+      typescript53:
+        specifier: npm:typescript@5.3
+        version: typescript@5.3.3
+      typescript54:
+        specifier: npm:typescript@5.4
+        version: typescript@5.4.2
+      typescript55:
+        specifier: npm:typescript@5.5
+        version: typescript@5.5.4
 
   fixtures/sample:
     dependencies:
@@ -1544,10 +1553,6 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
-  array-buffer-byte-length@1.0.1:
-    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
-    engines: {node: '>= 0.4'}
-
   array-differ@3.0.0:
     resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
     engines: {node: '>=8'}
@@ -1566,10 +1571,6 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-
-  arraybuffer.prototype.slice@1.0.3:
-    resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
-    engines: {node: '>= 0.4'}
 
   arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -1596,10 +1597,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  available-typed-arrays@1.0.7:
-    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
-    engines: {node: '>= 0.4'}
 
   axios@1.7.9:
     resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
@@ -1654,18 +1651,6 @@ packages:
     resolution: {integrity: sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  call-bind-apply-helpers@1.0.1:
-    resolution: {integrity: sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==}
-    engines: {node: '>= 0.4'}
-
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.2:
-    resolution: {integrity: sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==}
-    engines: {node: '>= 0.4'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1681,10 +1666,6 @@ packages:
   chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
-
-  chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
 
   chalk@4.1.0:
     resolution: {integrity: sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==}
@@ -1891,10 +1872,6 @@ packages:
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
 
-  cross-spawn@6.0.6:
-    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
-    engines: {node: '>=4.8'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1918,18 +1895,6 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
-
-  data-view-buffer@1.0.1:
-    resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-length@1.0.1:
-    resolution: {integrity: sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==}
-    engines: {node: '>= 0.4'}
-
-  data-view-byte-offset@1.0.0:
-    resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
-    engines: {node: '>= 0.4'}
 
   dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
@@ -1991,17 +1956,9 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2056,10 +2013,6 @@ packages:
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
-
-  dunder-proto@1.0.0:
-    resolution: {integrity: sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==}
-    engines: {node: '>= 0.4'}
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -2128,32 +2081,8 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
-  es-abstract@1.23.5:
-    resolution: {integrity: sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==}
-    engines: {node: '>= 0.4'}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
-
-  es-object-atoms@1.0.0:
-    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.0.3:
-    resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
-    engines: {node: '>= 0.4'}
-
-  es-to-primitive@1.3.0:
-    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
-    engines: {node: '>= 0.4'}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -2388,9 +2317,6 @@ packages:
       debug:
         optional: true
 
-  for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-
   for-in@1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
@@ -2449,20 +2375,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  function.prototype.name@1.1.6:
-    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
-    engines: {node: '>= 0.4'}
-
-  functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-intrinsic@1.2.6:
-    resolution: {integrity: sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==}
-    engines: {node: '>= 0.4'}
 
   get-pkg-repo@4.2.1:
     resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
@@ -2484,10 +2399,6 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-symbol-description@1.0.2:
-    resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
-    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
@@ -2550,20 +2461,12 @@ packages:
     resolution: {integrity: sha512-49TewVEz0UxZjr1WYYsWpPrhyC/B/pA8Bq0fUmet2n+eR7yn0IvNzNaoBwnK6mdkzcN+se7Ez9zUgULTz2QH4g==}
     engines: {node: '>=18'}
 
-  globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
-
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2584,31 +2487,9 @@ packages:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
 
-  has-bigints@1.0.2:
-    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
-
-  has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
-  has-proto@1.2.0:
-    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
@@ -2728,10 +2609,6 @@ packages:
     resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
     engines: {node: '>=12.0.0'}
 
-  internal-slot@1.1.0:
-    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
-    engines: {node: '>= 0.4'}
-
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
@@ -2744,28 +2621,8 @@ packages:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
     engines: {node: '>=0.10.0'}
 
-  is-array-buffer@3.0.4:
-    resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
-    engines: {node: '>= 0.4'}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-async-function@2.0.0:
-    resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
-    engines: {node: '>= 0.4'}
-
-  is-bigint@1.1.0:
-    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
-    engines: {node: '>= 0.4'}
-
-  is-boolean-object@1.2.1:
-    resolution: {integrity: sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==}
-    engines: {node: '>= 0.4'}
-
-  is-callable@1.2.7:
-    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
-    engines: {node: '>= 0.4'}
 
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
@@ -2773,14 +2630,6 @@ packages:
 
   is-core-module@2.16.0:
     resolution: {integrity: sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==}
-    engines: {node: '>= 0.4'}
-
-  is-data-view@1.0.2:
-    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
   is-docker@2.2.1:
@@ -2791,10 +2640,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-finalizationregistry@1.1.0:
-    resolution: {integrity: sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==}
-    engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@2.0.0:
     resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
@@ -2807,10 +2652,6 @@ packages:
   is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
-
-  is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
-    engines: {node: '>= 0.4'}
 
   is-git-repository@1.1.1:
     resolution: {integrity: sha512-hxLpJytJnIZ5Og5QsxSkzmb8Qx8rGau9bio1JN/QtXcGEFuSsQYau0IiqlsCwftsfVYjF1mOq6uLdmwNSspgpA==}
@@ -2826,20 +2667,8 @@ packages:
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
-  is-map@2.0.3:
-    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
-    engines: {node: '>= 0.4'}
-
-  is-negative-zero@2.0.3:
-    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
-    engines: {node: '>= 0.4'}
-
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
-
-  is-number-object@1.1.0:
-    resolution: {integrity: sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==}
-    engines: {node: '>= 0.4'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2864,21 +2693,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
-
   is-relative@1.0.0:
     resolution: {integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==}
     engines: {node: '>=0.10.0'}
-
-  is-set@2.0.3:
-    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
-    engines: {node: '>= 0.4'}
-
-  is-shared-array-buffer@1.0.3:
-    resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
-    engines: {node: '>= 0.4'}
 
   is-ssh@1.4.0:
     resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
@@ -2895,14 +2712,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-string@1.1.0:
-    resolution: {integrity: sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==}
-    engines: {node: '>= 0.4'}
-
-  is-symbol@1.1.1:
-    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
-    engines: {node: '>= 0.4'}
-
   is-text-path@1.0.1:
     resolution: {integrity: sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==}
     engines: {node: '>=0.10.0'}
@@ -2911,10 +2720,6 @@ packages:
     resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
     engines: {node: '>=8'}
 
-  is-typed-array@1.1.13:
-    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
-    engines: {node: '>= 0.4'}
-
   is-unc-path@1.0.0:
     resolution: {integrity: sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==}
     engines: {node: '>=0.10.0'}
@@ -2922,18 +2727,6 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-weakmap@2.0.2:
-    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
-    engines: {node: '>= 0.4'}
-
-  is-weakref@1.1.0:
-    resolution: {integrity: sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==}
-    engines: {node: '>= 0.4'}
-
-  is-weakset@2.0.3:
-    resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
-    engines: {node: '>= 0.4'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -2945,9 +2738,6 @@ packages:
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-
-  isarray@2.0.5:
-    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3223,16 +3013,8 @@ packages:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
 
-  math-intrinsics@1.0.0:
-    resolution: {integrity: sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==}
-    engines: {node: '>= 0.4'}
-
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
-
-  memorystream@0.3.1:
-    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
-    engines: {node: '>= 0.10.0'}
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -3408,9 +3190,6 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -3476,11 +3255,6 @@ packages:
     resolution: {integrity: sha512-5+bKQRH0J1xG1uZ1zMNvxW0VEyoNWgJpY9UDuluPFLKDfJ9u2JmmjmTJV1srBGQOROfdBMiVvnH2Zvpbm+xkVA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  npm-run-all@4.1.5:
-    resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
-    engines: {node: '>= 4'}
-    hasBin: true
-
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
     engines: {node: '>=4'}
@@ -3506,14 +3280,6 @@ packages:
 
   object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
-    engines: {node: '>= 0.4'}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
-  object.assign@4.1.5:
-    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
     engines: {node: '>= 0.4'}
 
   object.defaults@1.1.0:
@@ -3748,11 +3514,6 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  pidtree@0.3.1:
-    resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-
   pidtree@0.5.0:
     resolution: {integrity: sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==}
     engines: {node: '>=0.10'}
@@ -3802,10 +3563,6 @@ packages:
   pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
     engines: {node: '>=12.13.0'}
-
-  possible-typed-array-names@1.0.0:
-    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
-    engines: {node: '>= 0.4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -3956,19 +3713,11 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
-  reflect.getprototypeof@1.0.8:
-    resolution: {integrity: sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==}
-    engines: {node: '>= 0.4'}
-
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
-
-  regexp.prototype.flags@1.5.3:
-    resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
-    engines: {node: '>= 0.4'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4047,19 +3796,11 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
-  safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
-    engines: {node: '>=0.4'}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-regex-test@1.1.0:
-    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
-    engines: {node: '>= 0.4'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -4093,14 +3834,6 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
-
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -4123,10 +3856,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.2:
-    resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
-    engines: {node: '>= 0.4'}
 
   sherif-darwin-arm64@1.1.1:
     resolution: {integrity: sha512-67WeOqkp6/glNIvNINi5FjFmyJU65XUmA+ow16DBHXaR3C7mA6eQNjP3Ro3EMLRXzzvj9cMJ0k7vLsbxWCzBkw==}
@@ -4161,22 +3890,6 @@ packages:
   sherif@1.1.1:
     resolution: {integrity: sha512-571FkeQKaRZJJj4w55LEATkUC2kkoxkdlYuBx3V5N+O3P++4dgpCO1+goQBHbVJivmTpL7zkcLWLfymWf1BtUw==}
     hasBin: true
-
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4314,22 +4027,6 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
-  string.prototype.padend@3.1.6:
-    resolution: {integrity: sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trim@1.2.10:
-    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimend@1.0.9:
-    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.trimstart@1.0.8:
-    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
-    engines: {node: '>= 0.4'}
-
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -4387,10 +4084,6 @@ packages:
 
   summary@2.1.0:
     resolution: {integrity: sha512-nMIjMrd5Z2nuB2RZCKJfFMjgS3fygbeyGk9PxPPaJR1RIcyN9yn4A63Isovzm3ZtQuEkLBVgMdPup8UeLH7aQw==}
-
-  supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4583,22 +4276,6 @@ packages:
     resolution: {integrity: sha512-ojFL7eDMX2NF0xMbDwPZJ8sb7ckqtlAi1GsmgsFXvErT9kFTk1r0DuQKvrCh73M6D4nngeHJmvogF9OluXs7Hw==}
     engines: {node: '>=16'}
 
-  typed-array-buffer@1.0.2:
-    resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-length@1.0.1:
-    resolution: {integrity: sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-byte-offset@1.0.3:
-    resolution: {integrity: sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-length@1.0.7:
-    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
-    engines: {node: '>= 0.4'}
-
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
@@ -4632,8 +4309,18 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4652,9 +4339,6 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-
-  unbox-primitive@1.0.2:
-    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
   unc-path-regex@0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
@@ -4888,22 +4572,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  which-boxed-primitive@1.1.0:
-    resolution: {integrity: sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==}
-    engines: {node: '>= 0.4'}
-
-  which-builtin-type@1.2.1:
-    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
-    engines: {node: '>= 0.4'}
-
-  which-collection@1.0.2:
-    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
-    engines: {node: '>= 0.4'}
-
-  which-typed-array@1.1.16:
-    resolution: {integrity: sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==}
-    engines: {node: '>= 0.4'}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -6438,11 +6106,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  array-buffer-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      is-array-buffer: 3.0.4
-
   array-differ@3.0.0: {}
 
   array-each@1.0.1: {}
@@ -6452,17 +6115,6 @@ snapshots:
   array-slice@1.1.0: {}
 
   array-union@2.1.0: {}
-
-  arraybuffer.prototype.slice@1.0.3:
-    dependencies:
-      array-buffer-byte-length: 1.0.1
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.23.5
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.6
-      is-array-buffer: 3.0.4
-      is-shared-array-buffer: 1.0.3
 
   arrify@1.0.1: {}
 
@@ -6477,10 +6129,6 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
-
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.0.0
 
   axios@1.7.9:
     dependencies:
@@ -6552,23 +6200,6 @@ snapshots:
       tar: 6.2.1
       unique-filename: 3.0.0
 
-  call-bind-apply-helpers@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bind@1.0.8:
-    dependencies:
-      call-bind-apply-helpers: 1.0.1
-      es-define-property: 1.0.1
-      get-intrinsic: 1.2.6
-      set-function-length: 1.2.2
-
-  call-bound@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.2.6
-
   callsites@3.1.0: {}
 
   camelcase-keys@6.2.2:
@@ -6586,12 +6217,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.1.2
       pathval: 2.0.0
-
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
 
   chalk@4.1.0:
     dependencies:
@@ -6797,14 +6422,6 @@ snapshots:
       shebang-command: 1.2.0
       which: 1.3.1
 
-  cross-spawn@6.0.6:
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -6829,24 +6446,6 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.1.0
-
-  data-view-buffer@1.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
-
-  data-view-byte-offset@1.0.0:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      is-data-view: 1.0.2
 
   dateformat@3.0.3: {}
 
@@ -6885,19 +6484,7 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
   define-lazy-prop@2.0.0: {}
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
@@ -6934,12 +6521,6 @@ snapshots:
       dotenv: 16.4.7
 
   dotenv@16.4.7: {}
-
-  dunder-proto@1.0.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   duplexer@0.1.2: {}
 
@@ -6997,76 +6578,7 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-abstract@1.23.5:
-    dependencies:
-      array-buffer-byte-length: 1.0.1
-      arraybuffer.prototype.slice: 1.0.3
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      data-view-buffer: 1.0.1
-      data-view-byte-length: 1.0.1
-      data-view-byte-offset: 1.0.0
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.0.0
-      es-set-tostringtag: 2.0.3
-      es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.6
-      get-intrinsic: 1.2.6
-      get-symbol-description: 1.0.2
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      internal-slot: 1.1.0
-      is-array-buffer: 3.0.4
-      is-callable: 1.2.7
-      is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
-      is-regex: 1.2.1
-      is-shared-array-buffer: 1.0.3
-      is-string: 1.1.0
-      is-typed-array: 1.1.13
-      is-weakref: 1.1.0
-      object-inspect: 1.13.3
-      object-keys: 1.1.1
-      object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.3
-      safe-array-concat: 1.1.3
-      safe-regex-test: 1.1.0
-      string.prototype.trim: 1.2.10
-      string.prototype.trimend: 1.0.9
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.2
-      typed-array-byte-length: 1.0.1
-      typed-array-byte-offset: 1.0.3
-      typed-array-length: 1.0.7
-      unbox-primitive: 1.0.2
-      which-typed-array: 1.1.16
-
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
   es-module-lexer@1.5.4: {}
-
-  es-object-atoms@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.0.3:
-    dependencies:
-      get-intrinsic: 1.2.6
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-
-  es-to-primitive@1.3.0:
-    dependencies:
-      is-callable: 1.2.7
-      is-date-object: 1.1.0
-      is-symbol: 1.1.1
 
   esbuild-register@3.6.0(esbuild@0.24.0):
     dependencies:
@@ -7412,10 +6924,6 @@ snapshots:
 
   follow-redirects@1.15.9: {}
 
-  for-each@0.3.3:
-    dependencies:
-      is-callable: 1.2.7
-
   for-in@1.0.2: {}
 
   for-own@1.0.0:
@@ -7471,29 +6979,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  function.prototype.name@1.1.6:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.23.5
-      functions-have-names: 1.2.3
-
-  functions-have-names@1.2.3: {}
-
   get-caller-file@2.0.5: {}
-
-  get-intrinsic@1.2.6:
-    dependencies:
-      call-bind-apply-helpers: 1.0.1
-      dunder-proto: 1.0.0
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.0.0
-      function-bind: 1.1.2
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.2
-      math-intrinsics: 1.0.0
 
   get-pkg-repo@4.2.1:
     dependencies:
@@ -7509,12 +6995,6 @@ snapshots:
   get-stream@6.0.0: {}
 
   get-stream@6.0.1: {}
-
-  get-symbol-description@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.6
 
   get-tsconfig@4.8.1:
     dependencies:
@@ -7596,11 +7076,6 @@ snapshots:
 
   globals@15.13.0: {}
 
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
-
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -7611,8 +7086,6 @@ snapshots:
       slash: 3.0.0
 
   globrex@0.1.2: {}
-
-  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -7631,25 +7104,7 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  has-bigints@1.0.2: {}
-
-  has-flag@3.0.0: {}
-
   has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
-  has-proto@1.2.0:
-    dependencies:
-      dunder-proto: 1.0.0
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
 
   has-unicode@2.0.1: {}
 
@@ -7779,12 +7234,6 @@ snapshots:
       through: 2.3.8
       wrap-ansi: 6.2.0
 
-  internal-slot@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      hasown: 2.0.2
-      side-channel: 1.1.0
-
   interpret@3.1.1: {}
 
   ip-address@9.0.5:
@@ -7797,27 +7246,7 @@ snapshots:
       is-relative: 1.0.0
       is-windows: 1.0.2
 
-  is-array-buffer@3.0.4:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.2.6
-
   is-arrayish@0.2.1: {}
-
-  is-async-function@2.0.0:
-    dependencies:
-      has-tostringtag: 1.0.2
-
-  is-bigint@1.1.0:
-    dependencies:
-      has-bigints: 1.0.2
-
-  is-boolean-object@1.2.1:
-    dependencies:
-      call-bound: 1.0.2
-      has-tostringtag: 1.0.2
-
-  is-callable@1.2.7: {}
 
   is-ci@3.0.1:
     dependencies:
@@ -7827,34 +7256,15 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
-  is-data-view@1.0.2:
-    dependencies:
-      call-bound: 1.0.2
-      get-intrinsic: 1.2.6
-      is-typed-array: 1.1.13
-
-  is-date-object@1.1.0:
-    dependencies:
-      call-bound: 1.0.2
-      has-tostringtag: 1.0.2
-
   is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
-
-  is-finalizationregistry@1.1.0:
-    dependencies:
-      call-bind: 1.0.8
 
   is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@4.0.0: {}
-
-  is-generator-function@1.0.10:
-    dependencies:
-      has-tostringtag: 1.0.2
 
   is-git-repository@1.1.1:
     dependencies:
@@ -7869,16 +7279,7 @@ snapshots:
 
   is-lambda@1.0.1: {}
 
-  is-map@2.0.3: {}
-
-  is-negative-zero@2.0.3: {}
-
   is-node-process@1.2.0: {}
-
-  is-number-object@1.1.0:
-    dependencies:
-      call-bind: 1.0.8
-      has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
 
@@ -7894,22 +7295,9 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.2
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
-
   is-relative@1.0.0:
     dependencies:
       is-unc-path: 1.0.0
-
-  is-set@2.0.3: {}
-
-  is-shared-array-buffer@1.0.3:
-    dependencies:
-      call-bind: 1.0.8
 
   is-ssh@1.4.0:
     dependencies:
@@ -7921,17 +7309,6 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  is-string@1.1.0:
-    dependencies:
-      call-bind: 1.0.8
-      has-tostringtag: 1.0.2
-
-  is-symbol@1.1.1:
-    dependencies:
-      call-bound: 1.0.2
-      has-symbols: 1.1.0
-      safe-regex-test: 1.1.0
-
   is-text-path@1.0.1:
     dependencies:
       text-extensions: 1.9.0
@@ -7940,26 +7317,11 @@ snapshots:
     dependencies:
       text-extensions: 2.4.0
 
-  is-typed-array@1.1.13:
-    dependencies:
-      which-typed-array: 1.1.16
-
   is-unc-path@1.0.0:
     dependencies:
       unc-path-regex: 0.1.2
 
   is-unicode-supported@0.1.0: {}
-
-  is-weakmap@2.0.2: {}
-
-  is-weakref@1.1.0:
-    dependencies:
-      call-bound: 1.0.2
-
-  is-weakset@2.0.3:
-    dependencies:
-      call-bind: 1.0.8
-      get-intrinsic: 1.2.6
 
   is-windows@1.0.2: {}
 
@@ -7968,8 +7330,6 @@ snapshots:
       is-docker: 2.2.1
 
   isarray@1.0.0: {}
-
-  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -8401,11 +7761,7 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  math-intrinsics@1.0.0: {}
-
   mdurl@2.0.0: {}
-
-  memorystream@0.3.1: {}
 
   meow@12.1.1: {}
 
@@ -8581,8 +7937,6 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nice-try@1.0.5: {}
-
   node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -8673,18 +8027,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  npm-run-all@4.1.5:
-    dependencies:
-      ansi-styles: 3.2.1
-      chalk: 2.4.2
-      cross-spawn: 6.0.6
-      memorystream: 0.3.1
-      minimatch: 3.1.2
-      pidtree: 0.3.1
-      read-pkg: 3.0.0
-      shell-quote: 1.8.2
-      string.prototype.padend: 3.1.6
-
   npm-run-path@2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -8745,15 +8087,6 @@ snapshots:
       - debug
 
   object-inspect@1.13.3: {}
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.5:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
 
   object.defaults@1.1.0:
     dependencies:
@@ -8993,8 +8326,6 @@ snapshots:
 
   picomatch@4.0.2: {}
 
-  pidtree@0.3.1: {}
-
   pidtree@0.5.0: {}
 
   pify@2.3.0: {}
@@ -9030,8 +8361,6 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@6.0.0: {}
-
-  possible-typed-array-names@1.0.0: {}
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -9175,27 +8504,9 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  reflect.getprototypeof@1.0.8:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      dunder-proto: 1.0.0
-      es-abstract: 1.23.5
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.6
-      gopd: 1.2.0
-      which-builtin-type: 1.2.1
-
   regenerator-runtime@0.13.11: {}
 
   regenerator-runtime@0.14.1: {}
-
-  regexp.prototype.flags@1.5.3:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
 
@@ -9282,23 +8593,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  safe-array-concat@1.1.3:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.2
-      get-intrinsic: 1.2.6
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
-
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.2
-      es-errors: 1.3.0
-      is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
 
@@ -9343,22 +8640,6 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.6
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
-
   setprototypeof@1.2.0: {}
 
   shallow-clone@3.0.1:
@@ -9376,8 +8657,6 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.2: {}
 
   sherif-darwin-arm64@1.1.1:
     optional: true
@@ -9405,34 +8684,6 @@ snapshots:
       sherif-linux-x64: 1.1.1
       sherif-windows-arm64: 1.1.1
       sherif-windows-x64: 1.1.1
-
-  side-channel-list@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.3
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.2
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.6
-      object-inspect: 1.13.3
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.2
-      es-errors: 1.3.0
-      get-intrinsic: 1.2.6
-      object-inspect: 1.13.3
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.3
-      side-channel-list: 1.0.0
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -9583,36 +8834,6 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
-  string.prototype.padend@3.1.6:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.23.5
-      es-object-atoms: 1.0.0
-
-  string.prototype.trim@1.2.10:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.2
-      define-data-property: 1.1.4
-      define-properties: 1.2.1
-      es-abstract: 1.23.5
-      es-object-atoms: 1.0.0
-      has-property-descriptors: 1.0.2
-
-  string.prototype.trimend@1.0.9:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.2
-      define-properties: 1.2.1
-      es-object-atoms: 1.0.0
-
-  string.prototype.trimstart@1.0.8:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-object-atoms: 1.0.0
-
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -9661,10 +8882,6 @@ snapshots:
       peek-readable: 4.1.0
 
   summary@2.1.0: {}
-
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -9827,39 +9044,6 @@ snapshots:
 
   type-fest@4.30.1: {}
 
-  typed-array-buffer@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-      es-errors: 1.3.0
-      is-typed-array: 1.1.13
-
-  typed-array-byte-length@1.0.1:
-    dependencies:
-      call-bind: 1.0.8
-      for-each: 0.3.3
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.13
-
-  typed-array-byte-offset@1.0.3:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      for-each: 0.3.3
-      gopd: 1.2.0
-      has-proto: 1.2.0
-      is-typed-array: 1.1.13
-      reflect.getprototypeof: 1.0.8
-
-  typed-array-length@1.0.7:
-    dependencies:
-      call-bind: 1.0.8
-      for-each: 0.3.3
-      gopd: 1.2.0
-      is-typed-array: 1.1.13
-      possible-typed-array-names: 1.0.0
-      reflect.getprototypeof: 1.0.8
-
   typedarray@0.0.6: {}
 
   typedoc-plugin-frontmatter@1.1.2(typedoc-plugin-markdown@4.3.2(typedoc@0.27.5(typescript@5.6.3))):
@@ -9892,7 +9076,11 @@ snapshots:
 
   typescript@4.9.5: {}
 
+  typescript@5.3.3: {}
+
   typescript@5.4.2: {}
+
+  typescript@5.5.4: {}
 
   typescript@5.6.3: {}
 
@@ -9902,13 +9090,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  unbox-primitive@1.0.2:
-    dependencies:
-      call-bind: 1.0.8
-      has-bigints: 1.0.2
-      has-symbols: 1.1.0
-      which-boxed-primitive: 1.1.0
 
   unc-path-regex@0.1.2: {}
 
@@ -10112,45 +9293,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  which-boxed-primitive@1.1.0:
-    dependencies:
-      is-bigint: 1.1.0
-      is-boolean-object: 1.2.1
-      is-number-object: 1.1.0
-      is-string: 1.1.0
-      is-symbol: 1.1.1
-
-  which-builtin-type@1.2.1:
-    dependencies:
-      call-bound: 1.0.2
-      function.prototype.name: 1.1.6
-      has-tostringtag: 1.0.2
-      is-async-function: 2.0.0
-      is-date-object: 1.1.0
-      is-finalizationregistry: 1.1.0
-      is-generator-function: 1.0.10
-      is-regex: 1.2.1
-      is-weakref: 1.1.0
-      isarray: 2.0.5
-      which-boxed-primitive: 1.1.0
-      which-collection: 1.0.2
-      which-typed-array: 1.1.16
-
-  which-collection@1.0.2:
-    dependencies:
-      is-map: 2.0.3
-      is-set: 2.0.3
-      is-weakmap: 2.0.2
-      is-weakset: 2.0.3
-
-  which-typed-array@1.1.16:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      for-each: 0.3.3
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which@1.3.1:
     dependencies:


### PR DESCRIPTION
We theoretically support down to 4.5, which is what this casebase was at before...

However, [according to NPM data](https://majors.nullvoxpopuli.com/q?minors=on&old=&packages=typescript), none of the other versions of TypeScript 4.x are as widely used today as 4.9, so we'll be using that as our officially supported minimum version going forward.

![image](https://github.com/user-attachments/assets/f496e588-f720-46db-a9ca-20bdd1ff129e)
