### PR TITLE
fix: dependency tree of installed `node-vibrant` should no longer include Vite

### DIFF
--- a/packages/vibrant-generator-default/package.json
+++ b/packages/vibrant-generator-default/package.json
@@ -28,7 +28,9 @@
 	"dependencies": {
 		"@tanstack/config": "^0.15.0",
 		"@vibrant/color": "^4.0.0",
-		"@vibrant/generator": "^4.0.0",
+		"@vibrant/generator": "^4.0.0"
+	},
+	"devDependencies": {
 		"vite": "^6.0.5"
 	},
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,7 @@ importers:
       '@vibrant/generator':
         specifier: ^4.0.0
         version: link:../vibrant-generator
+    devDependencies:
       vite:
         specifier: ^6.0.5
         version: 6.0.6(@types/node@22.10.2)(jiti@2.4.1)(terser@5.37.0)(yaml@2.7.0)


### PR DESCRIPTION
Fixes #172